### PR TITLE
修复不能检测到“{}{\fn字体名}”的 bug

### DIFF
--- a/AssFontSubset/Subtitle.cs
+++ b/AssFontSubset/Subtitle.cs
@@ -195,7 +195,6 @@ namespace AssFontSubset
                     if (!fontDetected) {
                         overrideFontBegin = false;
                         overrideFontEnd = true;
-                        i += 1;
                         continue;
                     }
 


### PR DESCRIPTION
test file attached.
[test.zip](https://github.com/youlun/AssFontSubset/files/3089252/test.zip)
