### PR TITLE
修复三处可能导致字体的 fallback 的问题

### DIFF
--- a/AssFontSubset/MainWindow.xaml.cs
+++ b/AssFontSubset/MainWindow.xaml.cs
@@ -263,6 +263,27 @@ namespace AssFontSubset
             foreach (var text in textsInAss) {
                 var fontName = text.Key;
                 var characters = text.Value;
+                
+                // get around unknown bugs in subset fonts
+                characters = characters.Replace("…", "……");
+
+                // remove all regular numeric characters and replace them with a full set of them.
+                var halfwidth_numerical = new Regex(@"[0-9]");
+                if (halfwidth_numerical.IsMatch(characters))
+                {
+                    characters = halfwidth_numerical.Replace(characters, "");
+                    characters += "0123456789";
+                }
+
+
+                // remove all full width numeric characters and replace them with a full set of them.
+                var fullwidth_numerical = new Regex(@"１２３４５６７８９０");
+                if (fullwidth_numerical.IsMatch(characters))
+                {
+                    characters = fullwidth_numerical.Replace(characters, "");
+                    characters += "１２３４５６７８９０";
+                }
+                
 
                 var charactersFile = $@"{fontFolder}\{fontName}.txt";
                 using (StreamWriter sw = new StreamWriter(charactersFile, false, new UTF8Encoding(false))) {

--- a/AssFontSubset/Properties/AssemblyInfo.cs
+++ b/AssFontSubset/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // 可以指定所有值，也可以使用以下所示的 "*" 预置版本号和修订号
 // 方法是按如下所示使用“*”: :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.23.3333")]
-[assembly: AssemblyFileVersion("1.1.23.3333")]
+[assembly: AssemblyVersion("1.1.24.0")]
+[assembly: AssemblyFileVersion("1.1.24.0")]


### PR DESCRIPTION
1. 把 … 替换成 …… 以防止省略号 fallback。
2. 在子集化某些字体时，如果使用 vsfilter 系字幕滤镜，如果数字不全，可能会导致数字 fallback。因此，在字体有用到任意一个数字时，强制添加一整套数字进去。
3. 全角数字同上。