### PR TITLE
修复省略号 fallback （部分）

### DIFF
--- a/AssFontSubset/MainWindow.xaml.cs
+++ b/AssFontSubset/MainWindow.xaml.cs
@@ -263,9 +263,10 @@ namespace AssFontSubset
             foreach (var text in textsInAss) {
                 var fontName = text.Key;
                 var characters = text.Value;
-                
-                // get around unknown bugs in subset fonts
-                characters = characters.Replace("…", "……");
+
+                // fix font fallback on ellipsis.
+                characters = Regex.Replace(characters, @"[a-zA-Z]", "", RegexOptions.Compiled);
+                characters += "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
                 // remove all regular numeric characters and replace them with a full set of them.
                 var halfwidth_numerical = new Regex(@"[0-9]");

--- a/AssFontSubset/Properties/AssemblyInfo.cs
+++ b/AssFontSubset/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // 可以指定所有值，也可以使用以下所示的 "*" 预置版本号和修订号
 // 方法是按如下所示使用“*”: :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.24.0")]
-[assembly: AssemblyFileVersion("1.1.24.0")]
+[assembly: AssemblyVersion("1.1.24.1")]
+[assembly: AssemblyFileVersion("1.1.24.1")]


### PR DESCRIPTION
加入整套英文可以修复部分字体省略号在 vsfilter 的 fallback 问题。
但是思源系列（和类似字体）省略号从中置变成下置的原因和解决方案依旧未知。