### PR TITLE
解决省略号问题

### DIFF
--- a/AssFontSubset/MainWindow.xaml.cs
+++ b/AssFontSubset/MainWindow.xaml.cs
@@ -263,9 +263,10 @@ namespace AssFontSubset
             foreach (var text in textsInAss) {
                 var fontName = text.Key;
                 var characters = text.Value;
-                
-                // get around unknown bugs in subset fonts
-                characters = characters.Replace("…", "……");
+
+                // fix font fallback on ellipsis.
+                characters = Regex.Replace(characters, @"[a-zA-Z]", "", RegexOptions.Compiled);
+                characters += "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
                 // remove all regular numeric characters and replace them with a full set of them.
                 var halfwidth_numerical = new Regex(@"[0-9]");

--- a/AssFontSubset/Properties/AssemblyInfo.cs
+++ b/AssFontSubset/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // 可以指定所有值，也可以使用以下所示的 "*" 预置版本号和修订号
 // 方法是按如下所示使用“*”: :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.24.0")]
-[assembly: AssemblyFileVersion("1.1.24.0")]
+[assembly: AssemblyVersion("1.1.24.1")]
+[assembly: AssemblyFileVersion("1.1.24.1")]

--- a/AssFontSubset/Properties/AssemblyInfo.cs
+++ b/AssFontSubset/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // 可以指定所有值，也可以使用以下所示的 "*" 预置版本号和修订号
 // 方法是按如下所示使用“*”: :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.24.1")]
-[assembly: AssemblyFileVersion("1.1.24.1")]
+[assembly: AssemblyVersion("1.1.24.2")]
+[assembly: AssemblyFileVersion("1.1.24.2")]


### PR DESCRIPTION
修复在 vsfilter 下播放内封子集的省略号问题：
1. 修复省略号 fallback
2. 修复思源系列字体省略号下置而非居中的问题